### PR TITLE
Disable Style/FetchEnvVar

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,6 +162,8 @@ Style/ConditionalAssignment:
   Enabled: false
 Style/EmptyMethod:
   EnforcedStyle: expanded
+Style/FetchEnvVar:
+  Enabled: false
 Style/For:
   Enabled: false
 Style/FormatString:


### PR DESCRIPTION
we prefer the `ENV['BLA']` over `ENV.fetch('BLA', nil)` style, which is suggested by this cop. Let's not enforce this.