### PR TITLE
disable naming/VariableNumber cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -104,6 +104,8 @@ Naming/MethodParameterName:
       - AllowedNames
   AllowedNames:
     - hd
+Naming/VariableNumber:
+  Enabled: false
 
 # Performance
 Performance/Casecmp:


### PR DESCRIPTION
I want to switch off this rule that tells you
```ruby
# bad:
:spass_subscription_1

# good:
:spass_subscription1
```
this doesn't seem right.